### PR TITLE
Use custom user agent

### DIFF
--- a/ScreenShot/src/tools/Constants.cs
+++ b/ScreenShot/src/tools/Constants.cs
@@ -32,12 +32,12 @@ namespace ScreenShot.src.tools
 #else
             SAVE_DIRECTORY + "config.json";
 #endif
-        
+
         public const string API_ENDPOINT_IS_AUTHORIZED = "isAuthorized";
 
         public const string API_ENDPOINT_UPLOAD_SCREENSHOT = "uploadScreenShot";
 
-        public const string USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36 Edg/90.0.818.66";
+        public const string USER_AGENT = $"{CREATOR}/{PROGRAM_NAME}/1.0";
 
         public const bool OVERRIDE_SERVER_WITH_LOCAL = false;
 


### PR DESCRIPTION
For an application using an API for a legitimate purpose, there's no reason to mimic a browser. Updated user agent to uniquely identify the application. 